### PR TITLE
Disable multiplexed session and direct access features when emulator host is set

### DIFF
--- a/third_party/datastax/proxy/proxy.go
+++ b/third_party/datastax/proxy/proxy.go
@@ -1918,8 +1918,14 @@ func (sc *SpannerClient) GetClient(ctx context.Context) (*spanner.Client, error)
 
 // NewSpannerClient creates a new instance of SpannerClient
 var NewSpannerClient = func(ctx context.Context, config Config, ot *otelgo.OpenTelemetry) iface.SpannerClientInterface {
-	// Enable direct access
-	os.Setenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS", "true")
+	// Check the environment variables for the Spanner emulator.
+	// If not set, enable multiplexed session and direct access features.
+	if os.Getenv("SPANNER_EMULATOR_HOST") == "" {
+		// Enable multiplexed sessions
+		os.Setenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS", "true")
+		// Enable direct access
+		os.Setenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS", "true")
+	}
 	// Implementation
 	// Configure gRPC connection pool with minimum connection timeout
 	pool := grpc.WithConnectParams(grpc.ConnectParams{

--- a/third_party/datastax/proxy/proxy.go
+++ b/third_party/datastax/proxy/proxy.go
@@ -1918,8 +1918,6 @@ func (sc *SpannerClient) GetClient(ctx context.Context) (*spanner.Client, error)
 
 // NewSpannerClient creates a new instance of SpannerClient
 var NewSpannerClient = func(ctx context.Context, config Config, ot *otelgo.OpenTelemetry) iface.SpannerClientInterface {
-	// Enable multiplexed sessions
-	os.Setenv("GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS", "true")
 	// Enable direct access
 	os.Setenv("GOOGLE_SPANNER_ENABLE_DIRECT_ACCESS", "true")
 	// Implementation


### PR DESCRIPTION
This change addresses an issue where the Emulator would hang when the multiplexed sessions flag was set to `true` by default. The PR removes this default setting. Customers can still enable the multiplexed session feature in production environments by manually setting the `GOOGLE_CLOUD_SPANNER_MULTIPLEXED_SESSIONS` flag : https://cloud.google.com/spanner/docs/sessions#multiplexed_sessions