### PR TITLE
Fix cicd unit tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,12 +42,19 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '1.21'
 
     - name: Build
       run: go build -v ./...
+    
+    - name: Run Third Party Unit Tests
+      run: |
+          go mod tidy 
+          go test -v ./{/third_party/datastax/proxycore,/third_party/datastax/proxy} 
 
-    - name: Test
-      run: go test -v ./...
+    - name: Run Unit Tests
+      run: |
+          go mod tidy
+          go test -v ./{/otel,/spanner,/tableConfig,/tableConfig,/translator,/utilities} 

--- a/third_party/datastax/proxy/proxy_test.go
+++ b/third_party/datastax/proxy/proxy_test.go
@@ -95,7 +95,6 @@ func generateTestAddrs(host string) (clusterPort int, clusterAddr, proxyAddr, ht
 }
 
 func TestNewProxyWithOtel(t *testing.T) {
-	// t.Skip("Skipping for now due to seg fault in CI/CD")
 	ctx := context.Background()
 
 	// Initialize a logger


### PR DESCRIPTION
Fixes broken CI/CD pipeline when running unit tests.

1. Fix data race in Test_Serve, this was detected when running proxy test with `-race` flag.
2. Fix concurrent access to same port by splitting unit tests under third_party/ dir.
3. Fixed invalid mock injections. Some mocks for proxy spanner client was never injected, so unit test were trying to connect to real Spanner database without any credentials set up.
4. No IT tests are running for now without all needed credentials and secrets set up.

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR
