### PR TITLE
doc: update limitations doc to add support for double type and use keyspace

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -20,6 +20,7 @@ This limitation is primarily due to the significant differences in schema manage
     | int                   |     ✓     |          INT64          |
     | bigint                |     ✓     |          INT64          |
     | float                 |     ✓     |          FLOAT64        |
+    | double                |     ✓     |          FLOAT64        |
     | boolean               |     ✓     |          BOOL           |
     | uuid                  |     ✓     |          STRING         |
     | map<text, boolean>    |     ✓     |          JSON           |
@@ -200,5 +201,5 @@ We only support limited [system Queries](https://docs.google.com/document/d/1kaz
  -  `SELECT * FROM system_virtual_schema.keyspaces`
  -  `SELECT * FROM system_virtual_schema.tables`
  -  `SELECT * FROM system_virtual_schema.columns`
- -  `USE "keyspace_name"`
+
 


### PR DESCRIPTION
The USE keyspace support added in https://github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/pull/22 and double type added in https://github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/pull/12
