### PR TITLE
Record granular spanner api called in request count and latency metrics

### DIFF
--- a/mocks/spanner/SpannerClientIface.go
+++ b/mocks/spanner/SpannerClientIface.go
@@ -56,18 +56,20 @@ func (_m *SpannerClientIface) Close() error {
 }
 
 // UpdateMapByKey provides a mock function with given fields: ctx, query
-func (_m *SpannerClientIface) UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (_m *SpannerClientIface) UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
-		panic("no return value specified for UpdateMapByKey")
+			panic("no return value specified for UpdateMapByKey")
 	}
 
 	var r0 *message.RowsResult
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, error)); ok {
-		return rf(ctx, query)
-	}
+	var r1 string
+	var r2 error
+
+	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+			r0, r1, r2 = rf(ctx, query)
+	} else {
 	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) *message.RowsResult); ok {
 		r0 = rf(ctx, query)
 	} else {
@@ -75,29 +77,38 @@ func (_m *SpannerClientIface) UpdateMapByKey(ctx context.Context, query response
 			r0 = ret.Get(0).(*message.RowsResult)
 		}
 	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) string); ok {
 		r1 = rf(ctx, query)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(string)
+		}
+	}
+			if rf, ok := ret.Get(2).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+					r2 = rf(ctx, query)
+			} else {
+					r2 = ret.Error(2)
+			}
 	}
 
-	return r0, r1
+	return r0, r1, r2
 }
 
 // DeleteUsingMutations provides a mock function with given fields: ctx, query
-func (_m *SpannerClientIface) DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (_m *SpannerClientIface) DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
-		panic("no return value specified for DeleteUsingMutations")
+			panic("no return value specified for DeleteUsingMutations")
 	}
 
 	var r0 *message.RowsResult
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, error)); ok {
-		return rf(ctx, query)
-	}
+	var r1 string
+	var r2 error
+
+	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+			r0, r1, r2 = rf(ctx, query)
+	} else {
 	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) *message.RowsResult); ok {
 		r0 = rf(ctx, query)
 	} else {
@@ -105,14 +116,22 @@ func (_m *SpannerClientIface) DeleteUsingMutations(ctx context.Context, query re
 			r0 = ret.Get(0).(*message.RowsResult)
 		}
 	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) string); ok {
 		r1 = rf(ctx, query)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(string)
+		}
 	}
 
-	return r0, r1
+			if rf, ok := ret.Get(2).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+					r2 = rf(ctx, query)
+			} else {
+					r2 = ret.Error(2)
+			}
+	}
+
+	return r0, r1, r2
 }
 
 // FilterAndExecuteBatch provides a mock function with given fields: ctx, queries
@@ -205,18 +224,20 @@ func (_m *SpannerClientIface) GetTableConfigs(ctx context.Context, query respons
 }
 
 // InsertOrUpdateMutation provides a mock function with given fields: ctx, query
-func (_m *SpannerClientIface) InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (_m *SpannerClientIface) InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
-		panic("no return value specified for InsertOrUpdateMutation")
+			panic("no return value specified for InsertOrUpdateMutation")
 	}
 
 	var r0 *message.RowsResult
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, error)); ok {
-		return rf(ctx, query)
-	}
+	var r1 string
+	var r2 error
+
+	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+			r0, r1, r2 = rf(ctx, query)
+	} else {
 	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) *message.RowsResult); ok {
 		r0 = rf(ctx, query)
 	} else {
@@ -224,29 +245,39 @@ func (_m *SpannerClientIface) InsertOrUpdateMutation(ctx context.Context, query 
 			r0 = ret.Get(0).(*message.RowsResult)
 		}
 	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) string); ok {
 		r1 = rf(ctx, query)
 	} else {
-		r1 = ret.Error(1)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(string)
+		}
 	}
 
-	return r0, r1
+			if rf, ok := ret.Get(2).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+					r2 = rf(ctx, query)
+			} else {
+					r2 = ret.Error(2)
+			}
+	}
+
+	return r0, r1, r2
 }
 
 // InsertUpdateOrDeleteStatement provides a mock function with given fields: ctx, query
-func (_m *SpannerClientIface) InsertUpdateOrDeleteStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (_m *SpannerClientIface) InsertUpdateOrDeleteStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	ret := _m.Called(ctx, query)
 
 	if len(ret) == 0 {
-		panic("no return value specified for InsertUpdateOrDeleteStatement")
+			panic("no return value specified for InsertUpdateOrDeleteStatement")
 	}
 
 	var r0 *message.RowsResult
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, error)); ok {
-		return rf(ctx, query)
-	}
+	var r1 string 
+	var r2 error
+
+	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+			r0, r1, r2 = rf(ctx, query)
+	} else {
 	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) *message.RowsResult); ok {
 		r0 = rf(ctx, query)
 	} else {
@@ -254,44 +285,63 @@ func (_m *SpannerClientIface) InsertUpdateOrDeleteStatement(ctx context.Context,
 			r0 = ret.Get(0).(*message.RowsResult)
 		}
 	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) string); ok {
 		r1 = rf(ctx, query)
 	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// SelectStatement provides a mock function with given fields: ctx, query
-func (_m *SpannerClientIface) SelectStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
-	ret := _m.Called(ctx, query)
-
-	if len(ret) == 0 {
-		panic("no return value specified for SelectStatement")
-	}
-
-	var r0 *message.RowsResult
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, error)); ok {
-		return rf(ctx, query)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) *message.RowsResult); ok {
-		r0 = rf(ctx, query)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*message.RowsResult)
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) error); ok {
-		r2 = rf(ctx, query)
-	} else {
-		r2 = ret.Error(1)
+			if rf, ok := ret.Get(2).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+					r2 = rf(ctx, query)
+			} else {
+					r2 = ret.Error(2)
+			}
 	}
 
-	return r0, r2
+	return r0, r1, r2
+}
+
+
+// SelectStatement provides a mock function with given fields: ctx, query
+
+func (_m *SpannerClientIface) SelectStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
+        ret := _m.Called(ctx, query)
+
+        if len(ret) == 0 {
+                panic("no return value specified for SelectStatement")
+        }
+
+        var r0 *message.RowsResult
+        var r1 string 
+        var r2 error
+        if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+                r0, r1, r2 = rf(ctx, query)  
+        } else {
+        if rf, ok := ret.Get(0).(func(context.Context, responsehandler.QueryMetadata) *message.RowsResult); ok {
+            r0 = rf(ctx, query)
+        } else {
+            if ret.Get(0) != nil {
+                r0 = ret.Get(0).(*message.RowsResult)
+            }
+        }
+        if rf, ok := ret.Get(1).(func(context.Context, responsehandler.QueryMetadata) string); ok {
+            r1 = rf(ctx, query)
+        } else {
+            if ret.Get(1) != nil {
+                r1 = ret.Get(1).(string)
+            }
+        }
+                if rf, ok := ret.Get(2).(func(context.Context, responsehandler.QueryMetadata) error); ok {
+                        r2 = rf(ctx, query)
+                } else {
+                        r2 = ret.Error(2)
+                }
+        }
+
+
+        return r0, r1, r2
 }
 
 // NewSpannerClientIface creates a new instance of SpannerClientIface. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/mocks/spanner/SpannerClientIface.go
+++ b/mocks/spanner/SpannerClientIface.go
@@ -116,33 +116,44 @@ func (_m *SpannerClientIface) DeleteUsingMutations(ctx context.Context, query re
 }
 
 // FilterAndExecuteBatch provides a mock function with given fields: ctx, queries
-func (_m *SpannerClientIface) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (_m *SpannerClientIface) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	ret := _m.Called(ctx, queries)
 
 	if len(ret) == 0 {
-		panic("no return value specified for FilterAndExecuteBatch")
+			panic("no return value specified for FilterAndExecuteBatch")
 	}
 
 	var r0 *message.RowsResult
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) (*message.RowsResult, error)); ok {
-		return rf(ctx, queries)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) *message.RowsResult); ok {
-		r0 = rf(ctx, queries)
+	var r1 string  
+	var r2 error  
+
+	if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+			r0, r1, r2 = rf(ctx, queries) 
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*message.RowsResult)
-		}
+			if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) *message.RowsResult); ok {
+					r0 = rf(ctx, queries)
+			} else {
+					if ret.Get(0) != nil {
+							r0 = ret.Get(0).(*message.RowsResult)
+					}
+			}
+
+			if rf, ok := ret.Get(1).(func(context.Context, []*responsehandler.QueryMetadata) string); ok { // Add this block for string
+					r1 = rf(ctx, queries)
+			} else {
+					if ret.Get(1) != nil {
+							r1 = ret.Get(1).(string)
+					}
+			}
+			if rf, ok := ret.Get(2).(func(context.Context, []*responsehandler.QueryMetadata) error); ok { // Adjust index to 2.
+					r2 = rf(ctx, queries)
+			} else {
+					r2 = ret.Error(2) 
+			}
+
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []*responsehandler.QueryMetadata) error); ok {
-		r1 = rf(ctx, queries)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0, r1, r2 
 }
 
 // GetTableConfigs provides a mock function with given fields: ctx, query

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -39,9 +39,10 @@ import (
 )
 
 type Attributes struct {
-	Method    string
-	Status    string
-	QueryType string
+	Method     string
+	Status     string
+	QueryType  string
+	SpannerAPI string
 }
 
 var (

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -46,11 +46,12 @@ type Attributes struct {
 }
 
 var (
-	attributeKeyDatabase  = attribute.Key("database")
-	attributeKeyMethod    = attribute.Key("method")
-	attributeKeyStatus    = attribute.Key("status")
-	attributeKeyInstance  = attribute.Key("instance")
-	attributeKeyQueryType = attribute.Key("query_type")
+	attributeKeyDatabase   = attribute.Key("database")
+	attributeKeyMethod     = attribute.Key("method")
+	attributeKeyStatus     = attribute.Key("status")
+	attributeKeyInstance   = attribute.Key("instance")
+	attributeKeyQueryType  = attribute.Key("query_type")
+	attributeKeySpannerAPI = attribute.Key("spanner_api")
 )
 
 // TracerProvider defines the interface for creating traces.
@@ -332,6 +333,7 @@ func (o *OpenTelemetry) RecordLatencyMetric(ctx context.Context, duration time.T
 	attr := o.attributeMap
 	attr = append(attr, attributeKeyMethod.String(attrs.Method))
 	attr = append(attr, attributeKeyQueryType.String(attrs.QueryType))
+	attr = append(attr, attributeKeySpannerAPI.String(attrs.SpannerAPI))
 	o.requestLatency.Record(ctx, int64(time.Since(duration).Milliseconds()), metric.WithAttributes(attr...))
 }
 
@@ -345,6 +347,7 @@ func (o *OpenTelemetry) RecordRequestCountMetric(ctx context.Context, attrs Attr
 	attr = append(attr, attributeKeyMethod.String(attrs.Method))
 	attr = append(attr, attributeKeyQueryType.String(attrs.QueryType))
 	attr = append(attr, attributeKeyStatus.String(attrs.Status))
+	attr = append(attr, attributeKeySpannerAPI.String(attrs.SpannerAPI))
 	o.requestCount.Add(ctx, 1, metric.WithAttributes(attr...))
 }
 

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -266,7 +266,7 @@ func TestSRecordLatency(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "handlePrepare"})
+	ot.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "Batch", QueryType: "ExecuteDML"})
 	assert.NoErrorf(t, err, "error occurred")
 	//when otel is disabled
 	cfg2 := &OTelConfig{
@@ -277,7 +277,7 @@ func TestSRecordLatency(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot1.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "handlePrepare"})
+	ot1.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "Batch", QueryType: "ExecuteDML"})
 
 	shutdownOpenTelemetryComponents(ds1)
 	assert.NoErrorf(t, err2, "error occurred")
@@ -308,7 +308,7 @@ func TestRecordRequestCountMetric(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot.RecordRequestCountMetric(cyx, Attributes{Method: "handlePrepare"})
+	ot.RecordRequestCountMetric(cyx, Attributes{Method: "Batch", Status: "OK", QueryType: "Commit"})
 
 	assert.NoErrorf(t, err, "error occurred")
 
@@ -321,7 +321,7 @@ func TestRecordRequestCountMetric(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot1.RecordRequestCountMetric(cyx, Attributes{Method: "handlePrepare"})
+	ot1.RecordRequestCountMetric(cyx, Attributes{Method: "Batch", Status: "OK", QueryType: "Commit"})
 
 	shutdownOpenTelemetryComponents(ds1)
 	assert.NoErrorf(t, err2, "error occurred")

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -266,7 +266,7 @@ func TestSRecordLatency(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "Batch", QueryType: "ExecuteDML"})
+	ot.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "Batch", SpannerAPI: "Commit"})
 	assert.NoErrorf(t, err, "error occurred")
 	//when otel is disabled
 	cfg2 := &OTelConfig{
@@ -277,7 +277,7 @@ func TestSRecordLatency(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot1.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "Batch", QueryType: "ExecuteDML"})
+	ot1.RecordLatencyMetric(cyx, time.Now(), Attributes{Method: "Batch", QueryType: "ExecuteBatchDML"})
 
 	shutdownOpenTelemetryComponents(ds1)
 	assert.NoErrorf(t, err2, "error occurred")
@@ -308,7 +308,7 @@ func TestRecordRequestCountMetric(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot.RecordRequestCountMetric(cyx, Attributes{Method: "Batch", Status: "OK", QueryType: "Commit"})
+	ot.RecordRequestCountMetric(cyx, Attributes{Method: "Batch", Status: "OK"})
 
 	assert.NoErrorf(t, err, "error occurred")
 
@@ -321,7 +321,7 @@ func TestRecordRequestCountMetric(t *testing.T) {
 	ds1 = append(ds1, ds)
 	assert.NoErrorf(t, err, "error occurred")
 
-	ot1.RecordRequestCountMetric(cyx, Attributes{Method: "Batch", Status: "OK", QueryType: "Commit"})
+	ot1.RecordRequestCountMetric(cyx, Attributes{Method: "Batch", Status: "OK"})
 
 	shutdownOpenTelemetryComponents(ds1)
 	assert.NoErrorf(t, err2, "error occurred")

--- a/spanner/spanner.go
+++ b/spanner/spanner.go
@@ -74,19 +74,19 @@ const (
 )
 
 const (
-	CommitAPI          = "Commit"
-	ExecuteBatchDMLAPI = "ExecuteBatchDML"
-	ExecuteSqlAPI      = "ExecuteSql"
-	UnknownOrMixedAPI  = ""
+	CommitAPI              = "Commit"
+	ExecuteBatchDMLAPI     = "ExecuteBatchDML"
+	ExecuteStreamingSqlAPI = "ExecuteStreamingSql"
+	UnknownOrMixedAPI      = ""
 )
 
 type SpannerClientIface interface {
-	SelectStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
-	InsertUpdateOrDeleteStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
+	SelectStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
+	InsertUpdateOrDeleteStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
 	Close() error
-	InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
-	DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
-	UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
+	InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
+	DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
+	UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
 	FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, string, error)
 	GetTableConfigs(ctx context.Context, query responsehandler.QueryMetadata) (map[string]map[string]*tableConfig.Column, map[string][]tableConfig.Column, *SystemQueryMetadataCache, error)
 }
@@ -149,7 +149,7 @@ type SystemQueryMetadataCache struct {
 //   - query: query metadata.
 //
 // Returns: message.RowsResult (supported response format to the cassandra client) and error.
-func (sc *SpannerClient) SelectStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (sc *SpannerClient) SelectStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	var columnMetadata []*message.ColumnMetadata
 	var data message.RowSet
 	var err error
@@ -171,20 +171,20 @@ func (sc *SpannerClient) SelectStatement(ctx context.Context, query responsehand
 			break
 		}
 		if err != nil {
-			return nil, err
+			return nil, UnknownOrMixedAPI, err
 		}
 
 		if rowCount == 0 {
 			otelgo.AddAnnotation(ctx, "Encoding Spanner Response")
 			rowFuncs, columnMetadata, err = sc.ResponseHandler.BuildColumnMetadata(iter.Metadata.GetRowType(), query.ProtocalV, query.AliasMap, query.TableName, query.KeyspaceName)
 			if err != nil {
-				return nil, err
+				return nil, UnknownOrMixedAPI, err
 			}
 		}
 
 		mr, err := sc.ResponseHandler.BuildResponseRow(row, rowFuncs)
 		if err != nil {
-			return nil, err
+			return nil, UnknownOrMixedAPI, err
 		}
 		data = append(data, mr)
 		rowCount += 1
@@ -196,7 +196,7 @@ func (sc *SpannerClient) SelectStatement(ctx context.Context, query responsehand
 		columnMetadata, err = sc.ResponseHandler.TableConfig.GetMetadataForSelectedColumns(query.TableName, query.SelectedColumns, query.AliasMap)
 		if err != nil {
 			sc.Logger.Error("error while fetching columnMetadata from config -", zap.Error(err))
-			return nil, err
+			return nil, UnknownOrMixedAPI, err
 		}
 	}
 	result := &message.RowsResult{
@@ -206,7 +206,7 @@ func (sc *SpannerClient) SelectStatement(ctx context.Context, query responsehand
 		},
 		Data: data,
 	}
-	return result, nil
+	return result, ExecuteStreamingSqlAPI, nil
 }
 
 // InsertUpdateOrDeleteStatement - Handle Insert/Update/Delete Operation
@@ -216,7 +216,7 @@ func (sc *SpannerClient) SelectStatement(ctx context.Context, query responsehand
 //   - query: query metadata.
 //
 // Returns: message.RowsResult (supported response format to the cassandra client) and error.
-func (sc *SpannerClient) InsertUpdateOrDeleteStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (sc *SpannerClient) InsertUpdateOrDeleteStatement(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	otelgo.AddAnnotation(ctx, InsertUpdateOrDeleteStatement)
 	_, err := sc.Client.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		_, err := txn.Update(ctx, *buildStmt(&query))
@@ -226,7 +226,7 @@ func (sc *SpannerClient) InsertUpdateOrDeleteStatement(ctx context.Context, quer
 		return nil
 	}, spanner.TransactionOptions{CommitOptions: sc.BuildCommitOptions()})
 
-	return &rowsResult, err
+	return &rowsResult, ExecuteStreamingSqlAPI, err
 }
 
 // InsertOrUpdateMutation - Handle Insert/Update/Delete Operation
@@ -236,7 +236,7 @@ func (sc *SpannerClient) InsertUpdateOrDeleteStatement(ctx context.Context, quer
 //   - query: query metadata.
 //
 // Returns: message.RowsResult (supported response format to the cassandra client) and error.
-func (sc *SpannerClient) InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (sc *SpannerClient) InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	otelgo.AddAnnotation(ctx, InsertOrUpdateMutation)
 	if query.HasIfNotExists {
 		return sc.InsertMutation(ctx, query)
@@ -247,9 +247,9 @@ func (sc *SpannerClient) InsertOrUpdateMutation(ctx context.Context, query respo
 			[]*spanner.Mutation{buildInsertOrUpdateMutation(&query)},
 			spanner.ApplyAtLeastOnce(),
 			spanner.ApplyCommitOptions(sc.BuildCommitOptions())); err != nil {
-			return nil, err
+			return nil, UnknownOrMixedAPI, err
 		}
-		return &rowsResult, nil
+		return &rowsResult, CommitAPI, nil
 	}
 
 	_, err := sc.Client.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
@@ -277,7 +277,7 @@ func (sc *SpannerClient) InsertOrUpdateMutation(ctx context.Context, query respo
 		return nil
 	}, spanner.TransactionOptions{CommitOptions: sc.BuildCommitOptions()})
 
-	return &rowsResult, err
+	return &rowsResult, CommitAPI, err
 }
 
 // InsertOrUpdateMutation - Handle Insert Operation
@@ -287,7 +287,7 @@ func (sc *SpannerClient) InsertOrUpdateMutation(ctx context.Context, query respo
 //   - query: query metadata.
 //
 // Returns: message.RowsResult (supported response format to the cassandra client) and error.
-func (sc *SpannerClient) InsertMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (sc *SpannerClient) InsertMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	var err error
 	if sc.ReplayProtection {
 		_, err = sc.Client.Apply(ctx,
@@ -318,7 +318,7 @@ func (sc *SpannerClient) InsertMutation(ctx context.Context, query responsehandl
 			},
 		},
 		Data: message.RowSet{message.Row{row}},
-	}, nil
+	}, CommitAPI, nil
 }
 
 // Encode system_schema info to cassandra type
@@ -562,7 +562,7 @@ func ignoreInsert(iter *spanner.RowIterator) (bool, error) {
 //
 // Returns: message.RowsResult (supported response format to the cassandra client) and error.
 
-func (sc *SpannerClient) DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (sc *SpannerClient) DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	otelgo.AddAnnotation(ctx, DeleteUsingMutations)
 
 	var err error
@@ -578,10 +578,10 @@ func (sc *SpannerClient) DeleteUsingMutations(ctx context.Context, query respons
 	}
 	if err != nil {
 		sc.Logger.Error("Error while Mutation Delete - "+query.Query, zap.Error(err))
-		return nil, err
+		return nil, UnknownOrMixedAPI, err
 	}
 
-	return &rowsResult, err
+	return &rowsResult, CommitAPI, err
 }
 
 // UpdateMapByKey - Handle Update Map By Key Operation with pattern column[?] = true/false
@@ -592,7 +592,7 @@ func (sc *SpannerClient) DeleteUsingMutations(ctx context.Context, query respons
 //   - query: query metadata.
 //
 // Returns: message.RowsResult (supported response format to the cassandra client) and error.
-func (sc *SpannerClient) UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {
+func (sc *SpannerClient) UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	otelgo.AddAnnotation(ctx, "UpdateMapByKey")
 	stmt := spanner.Statement{
 		SQL:    query.SelectQueryMapUpdate,
@@ -634,7 +634,7 @@ func (sc *SpannerClient) UpdateMapByKey(ctx context.Context, query responsehandl
 		return nil
 	}, spanner.TransactionOptions{CommitOptions: sc.BuildCommitOptions()})
 
-	return &rowsResult, err
+	return &rowsResult, ExecuteStreamingSqlAPI, err
 }
 
 // executeQueryAndRetrieveResults - This function executes select statement, iterates rows and returns the results from Select Query.
@@ -716,7 +716,7 @@ func updateMapWithNewValues(mapValue map[string]bool, query *responsehandler.Que
 
 func (sc *SpannerClient) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
 	otelgo.AddAnnotation(ctx, FilterAndExecuteBatch)
-	spannerAPI := ""
+	var spannerAPI string
 	_, err := sc.Client.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 		filteredResponse, err := sc.filterBatch(ctx, txn, queries)
 		if err != nil {

--- a/spanner/spanner_test.go
+++ b/spanner/spanner_test.go
@@ -72,9 +72,6 @@ const (
 	NotFoundOnSpanner             = "Inserted Rows not found in spanner"
 	ErrorWhileFetchingFromSpanner = "Error while fetching data from Spanner: %v"
 	largestTimeStampMismatchError = "largest timestamp is not matching"
-	BatchCommit                   = "Commit"
-	BatchDML                      = "BatchDML"
-	BatchMixed                    = ""
 )
 
 var SCHEMAFILE embed.FS
@@ -1042,7 +1039,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with same PK: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithSamePK")
-			assert.Equal(t, BatchCommit, batchQueryType)
+			assert.Equal(t, CommitAPI, batchQueryType)
 		}
 
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_1' and `upload_time`= 5000000;")
@@ -1088,7 +1085,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with different PK: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithDifferentPK")
-			assert.Equal(t, BatchCommit, batchQueryType)
+			assert.Equal(t, CommitAPI, batchQueryType)
 		}
 
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_1' order by upload_time;")
@@ -1128,7 +1125,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			t.Errorf("Error while executing FilterAndExecuteBatch for range delete: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: RangeDelete")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_1' order by upload_time;")
@@ -1241,7 +1238,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with same PK: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithSamePK")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_1';")
@@ -1301,7 +1298,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDelete")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_2' order by upload_time;")
@@ -1349,7 +1346,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertWithSamePKFollowedByDelete")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_5' order by upload_time;")
@@ -1426,7 +1423,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDeleteOnSamePK")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_7X' order by upload_time;")
@@ -1481,7 +1478,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDeleteOnDifferentPK")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_7X' order by upload_time;")
@@ -1550,7 +1547,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKCase1")
-			assert.Equal(t, BatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDML, batchQueryType)
 		}
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_9' order by upload_time;")
 		assert.Error(t, fmt.Errorf("no rows found"), err, "all rows should have deleted for AllOperationWithSamePKCase1")

--- a/spanner/spanner_test.go
+++ b/spanner/spanner_test.go
@@ -535,11 +535,12 @@ func TestSelectStatement(t *testing.T) {
 	defer sc.Close()
 
 	query := mockQueryMetadata() // Assumes mockQueryMetadata is appropriately defined elsewhere
-	result, err := sc.SelectStatement(ctx, query)
+	result, spannerAPI, err := sc.SelectStatement(ctx, query)
 	if err != nil {
 		t.Errorf("Unexpected error in select query: %v", err)
 	}
 	assert.Equal(t, 1, len(result.Data), "there should not be any rows in result")
+	assert.Equal(t, ExecuteStreamingSqlAPI, spannerAPI)
 }
 
 func TestSelectStatementStale(t *testing.T) {
@@ -547,7 +548,7 @@ func TestSelectStatementStale(t *testing.T) {
 	defer sc.Close()
 
 	query := mockQueryMetadata() // Assumes mockQueryMetadata is appropriately defined elsewhere
-	result, err := sc.SelectStatement(ctx, query)
+	result, _, err := sc.SelectStatement(ctx, query)
 	if err != nil {
 		t.Errorf("Unexpected error in select query: %v", err)
 	}
@@ -622,7 +623,7 @@ func TestInsertUpdateOrDeleteStatement(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := sc.InsertUpdateOrDeleteStatement(ctx, tc.query)
+			result, spannerAPI, err := sc.InsertUpdateOrDeleteStatement(ctx, tc.query)
 			if tc.expectError {
 				if err == nil {
 					t.Errorf("Expected error but got nil for test case: %s", tc.name)
@@ -632,6 +633,7 @@ func TestInsertUpdateOrDeleteStatement(t *testing.T) {
 					t.Errorf("Error in InsertUpdateOrDeleteStatement for test case %s: %s", tc.name, err.Error())
 				}
 				assert.Equal(t, 0, len(result.Data), "unexpected number of rows in result for test case: "+tc.name)
+				assert.Equal(t, ExecuteStreamingSqlAPI, spannerAPI)
 			}
 		})
 	}
@@ -780,11 +782,12 @@ func TestInsertOrUpdateMutation(t *testing.T) {
 				UsingTSCheck: tc.usingTSCheck,
 				Params:       tc.params,
 			}
-			result, err := sc.InsertOrUpdateMutation(ctx, query)
+			result, spannerAPI, err := sc.InsertOrUpdateMutation(ctx, query)
 			if err != nil {
 				t.Errorf("Error in InsertOrUpdateMutation: %s", err.Error())
 			}
 			assert.Equal(t, 0, len(result.Data), "unexpected number of rows in result")
+			assert.Equal(t, CommitAPI, spannerAPI)
 			data, err := getDataFromSpanner(ctx, sc.Client, fmt.Sprintf("select * from keyspace1_comm_upload_event where user_id='%s';", tc.params["user_id"]))
 			if err != nil {
 				t.Errorf(ErrorWhileFetchingFromSpanner, err)
@@ -886,10 +889,11 @@ func TestDeleteUsingMutations(t *testing.T) {
 		Params:       map[string]interface{}{"value1": "0856e83c-81c3-430c-b018-9eb22ea3882a"},
 	}
 
-	_, err := sc.DeleteUsingMutations(ctx, query)
+	_, spannerAPI, err := sc.DeleteUsingMutations(ctx, query)
 	if err != nil {
 		t.Error("Error while function call DeleteUsingMutations")
 	}
+	assert.Equal(t, CommitAPI, spannerAPI)
 }
 
 func TestUpdateMapByKey(t *testing.T) {
@@ -950,9 +954,10 @@ func TestUpdateMapByKey(t *testing.T) {
 				},
 			}
 
-			result, err := sc.UpdateMapByKey(ctx, query)
+			result, spannerAPI, err := sc.UpdateMapByKey(ctx, query)
 			assert.NoError(t, err, "Unexpected error in UpdateMapByKey")
 			assert.Equal(t, 0, len(result.Data), "Result size should be 0 but found %d", len(result.Data))
+			assert.Equal(t, ExecuteStreamingSqlAPI, spannerAPI)
 
 			data, err := getDataFromSpanner(ctx, sc.Client, fmt.Sprintf("select * from keyspace1_address_book_entries WHERE `user_id`='%s';", tt.params["value1"]))
 			if err != nil {
@@ -1034,12 +1039,12 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			queries[i] = query
 		}
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with same PK: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithSamePK")
-			assert.Equal(t, CommitAPI, batchQueryType)
+			assert.Equal(t, CommitAPI, spannerAPI)
 		}
 
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_1' and `upload_time`= 5000000;")
@@ -1080,12 +1085,12 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			queries[i] = query
 		}
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with different PK: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithDifferentPK")
-			assert.Equal(t, CommitAPI, batchQueryType)
+			assert.Equal(t, CommitAPI, spannerAPI)
 		}
 
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_1' order by upload_time;")
@@ -1120,12 +1125,12 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			},
 		}
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for range delete: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: RangeDelete")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_1' order by upload_time;")
@@ -1172,7 +1177,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 	// 		queries = append(queries, query)
 	// 	}
 
-	// 	result, batchQueryType,  err := sc.FilterAndExecuteBatch(ctx, queries)
+	// 	result, spannerAPI,  err := sc.FilterAndExecuteBatch(ctx, queries)
 	// 	if err != nil {
 	// 		t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 	// 	} else {
@@ -1233,12 +1238,12 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 			queries = append(queries, query)
 		}
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with same PK: %v", err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithSamePK")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_1';")
@@ -1293,12 +1298,12 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			PrimaryKeys:  []string{"user_id", "upload_time"},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDelete")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_2' order by upload_time;")
@@ -1341,12 +1346,12 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			PrimaryKeys:  []string{"user_id", "upload_time"},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertWithSamePKFollowedByDelete")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_5' order by upload_time;")
@@ -1418,12 +1423,12 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			PrimaryKeys:  []string{"user_id", "upload_time"},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDeleteOnSamePK")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_7X' order by upload_time;")
@@ -1473,12 +1478,12 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 			PrimaryKeys:  []string{"user_id", "upload_time"},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDeleteOnDifferentPK")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='diff_pk_7X' order by upload_time;")
@@ -1542,12 +1547,12 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			PrimaryKeys:  []string{"user_id", "upload_time"},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKCase1")
-			assert.Equal(t, ExecuteBatchDML, batchQueryType)
+			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_9' order by upload_time;")
 		assert.Error(t, fmt.Errorf("no rows found"), err, "all rows should have deleted for AllOperationWithSamePKCase1")
@@ -1620,12 +1625,12 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			PrimaryKeys:  []string{"user_id"},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKey")
-			assert.Equal(t, BatchMixed, batchQueryType)
+			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		_, err = getDataFromSpanner(ctx, sc.Client, fmt.Sprintf("select * from %s WHERE `user_id`='same_pk_10';", TABLE_ADDRESS))
 		assert.Error(t, fmt.Errorf("no rows found"), err, "all rows should have deleted for AllOperationWithSamePKUpdateMapByKey")
@@ -1698,12 +1703,12 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
-			assert.Equal(t, BatchMixed, batchQueryType)
+			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_11';")
 		if err != nil {
@@ -1789,12 +1794,12 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			},
 		})
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase3")
-			assert.Equal(t, BatchMixed, batchQueryType)
+			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_12';")
 		if err != nil {
@@ -1874,12 +1879,12 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			})
 		}
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
-			assert.Equal(t, BatchMixed, batchQueryType)
+			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_13';")
 		if err != nil {
@@ -1932,12 +1937,12 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 			})
 		}
 
-		result, batchQueryType, err := sc.FilterAndExecuteBatch(ctx, queries)
+		result, spannerAPI, err := sc.FilterAndExecuteBatch(ctx, queries)
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
 			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
-			assert.Equal(t, BatchMixed, batchQueryType)
+			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_13';")
 		if err != nil {

--- a/third_party/datastax/proxy/proxy_test.go
+++ b/third_party/datastax/proxy/proxy_test.go
@@ -1367,9 +1367,9 @@ func Test_handleExecutionForDeletePreparedQuery(t *testing.T) {
 	}
 	spanmockface.On("GetTableConfigs", ctx, query).Return(columnMap, columnListMap, &spannerModule.SystemQueryMetadataCache{}, nil)
 	spanmockface.On("SelectStatement", ctx, queryForTest).Return(&message.RowsResult{}, nil)
-	spanmockface.On("InsertUpdateOrDeleteStatement", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, nil).Once()
-	spanmockface.On("InsertUpdateOrDeleteStatement", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, errors.New("error occured")).Once()
-	spanmockface.On("DeleteUsingMutations", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, errors.New("error occured"))
+	spanmockface.On("InsertUpdateOrDeleteStatement", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.ExecuteStreamingSqlAPI, nil).Once()
+	spanmockface.On("InsertUpdateOrDeleteStatement", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.UnknownOrMixedAPI, errors.New("error occured")).Once()
+	spanmockface.On("DeleteUsingMutations", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.UnknownOrMixedAPI, errors.New("error occured"))
 	p.sClient = spanmockface
 	p.translator = &translator.Translator{TableConfig: &tableConfig.TableConfig{
 		TablesMetaData:  columnMap,
@@ -1545,8 +1545,8 @@ func Test_client_handleExecutionForSelectPreparedQuery(t *testing.T) {
 	assert.NoErrorf(t, err, "failed to create the proxy instance")
 
 	spanmockface := new(spannerMock.SpannerClientIface)
-	spanmockface.On("SelectStatement", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, nil).Once()
-	spanmockface.On("SelectStatement", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, errors.New("error occured")).Once()
+	spanmockface.On("SelectStatement", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.ExecuteStreamingSqlAPI, nil).Once()
+	spanmockface.On("SelectStatement", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, "", errors.New("error occured")).Once()
 	mockProxy.sClient = spanmockface
 	type fields struct {
 		ctx                 context.Context
@@ -1642,8 +1642,8 @@ func Test_client_handleExecutionForInsertPreparedQuery(t *testing.T) {
 	}
 
 	spanmockface := new(spannerMock.SpannerClientIface)
-	spanmockface.On("InsertOrUpdateMutation", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, nil).Once()
-	spanmockface.On("InsertOrUpdateMutation", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, errors.New("error occured")).Once()
+	spanmockface.On("InsertOrUpdateMutation", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.CommitAPI, nil).Once()
+	spanmockface.On("InsertOrUpdateMutation", mockProxy.ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.UnknownOrMixedAPI, errors.New("error occured")).Once()
 	mockProxy.sClient = spanmockface
 	type fields struct {
 		ctx                 context.Context
@@ -1933,8 +1933,8 @@ func Test_client_handleExecutionForInsertPreparedQuery(t *testing.T) {
 // 	spanmockface := new(spannerMock.SpannerClientIface)
 // 	spanmockface.On("InsertUpdateOrDeleteStatement", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, nil).Once()
 // 	spanmockface.On("InsertUpdateOrDeleteStatement", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, errors.New("error occured")).Once()
-// 	spanmockface.On("UpdateMapByKey", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, nil).Once()
-// 	spanmockface.On("UpdateMapByKey", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, errors.New("error occured")).Once()
+// 	spanmockface.On("UpdateMapByKey", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.ExecuteStreamingSqlAPI, nil).Once()
+// 	spanmockface.On("UpdateMapByKey", ctx, mock.AnythingOfType("responsehandler.QueryMetadata")).Return(&message.RowsResult{}, spannerModule.UnknownOrMixedAPI, errors.New("error occured")).Once()
 // 	mockProxy.sClient = spanmockface
 
 // 	type fields struct {


### PR DESCRIPTION
Populate a new metric label `spanner_api` for all read/write operations.


Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
