### PR TITLE
set  project and instances to default for external hosts

### DIFF
--- a/schema_converter/README.md
+++ b/schema_converter/README.md
@@ -65,6 +65,10 @@ go run cql_to_spanner_schema_converter.go --project <PROJECT_ID> --instance <INS
 - `[--table]`: Optional flag to specify different table name for TableConfigurations.
 - `[--enableUsingTimestamp]`: Optional flag to enable 'Using Timestamp' features, default is false.
 - `[--enableUsingTTL]`: Optional flag to enable 'Using TTL' features, default is false.
+- `[--usePlainText]`: Optional flag to enable sing plain text connection for external host, default is false.
+- `[--caCertificate]`: Optional flag to specify the CA certificate file path required for TLS/mTLS connection for external hosts.
+- `[--clientCertificate]`: Optional flag to specify the client certificate file path required for mTLS connection for external hosts.
+- `[--clientKey]`: Optional flag to specify the client key file path required for mTLS connection for external hosts.
 
 ### 2. Example Commands
 

--- a/schema_converter/README.md
+++ b/schema_converter/README.md
@@ -65,7 +65,7 @@ go run cql_to_spanner_schema_converter.go --project <PROJECT_ID> --instance <INS
 - `[--table]`: Optional flag to specify different table name for TableConfigurations.
 - `[--enableUsingTimestamp]`: Optional flag to enable 'Using Timestamp' features, default is false.
 - `[--enableUsingTTL]`: Optional flag to enable 'Using TTL' features, default is false.
-- `[--usePlainText]`: Optional flag to enable sing plain text connection for external host, default is false.
+- `[--usePlainText]`: Optional flag to enable plain text connection for external host, default is false.
 - `[--caCertificate]`: Optional flag to specify the CA certificate file path required for TLS/mTLS connection for external hosts.
 - `[--clientCertificate]`: Optional flag to specify the client certificate file path required for mTLS connection for external hosts.
 - `[--clientKey]`: Optional flag to specify the client key file path required for mTLS connection for external hosts.

--- a/schema_converter/cql_to_spanner_schema_converter.go
+++ b/schema_converter/cql_to_spanner_schema_converter.go
@@ -154,8 +154,7 @@ func main() {
 
 	flag.Parse()
 
-	pattern := regexp.MustCompile(`.*\.googleapis\.com.*`)
-	isExternalHost := (*endpoint != "" && !pattern.MatchString(*endpoint))
+	isExternalHost := (*endpoint != "" && !regexp.MustCompile(`.*\.googleapis\.com.*`).MatchString(*endpoint))
 
 	if isExternalHost {
 		*projectID = "default"

--- a/schema_converter/cql_to_spanner_schema_converter.go
+++ b/schema_converter/cql_to_spanner_schema_converter.go
@@ -39,6 +39,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const (
+	ExternalHostProjectID  = "default"
+	ExternalHostInstanceID = "default"
+)
+
 type ColumnMetadata struct {
 	ColumnName   string
 	CQLType      string
@@ -157,8 +162,8 @@ func main() {
 	isExternalHost := (*endpoint != "" && !regexp.MustCompile(`.*\.googleapis\.com.*`).MatchString(*endpoint))
 
 	if isExternalHost {
-		*projectID = "default"
-		*instanceID = "default"
+		*projectID = ExternalHostProjectID
+		*instanceID = ExternalHostInstanceID
 	}
 
 	// Check if all required flags are provided

--- a/third_party/datastax/proxy/defaults.go
+++ b/third_party/datastax/proxy/defaults.go
@@ -54,7 +54,7 @@ func ValidateAndApplyDefaults(cfg *UserConfig) error {
 			return fmt.Errorf("database id is not defined for listener %s %d", cfg.Listeners[i].Name, cfg.Listeners[i].Port)
 		}
 		if cfg.CassandraToSpannerConfigs.Endpoint != "" && !regexp.MustCompile(`.*\.googleapis\.com.*`).MatchString(cfg.CassandraToSpannerConfigs.Endpoint) {
-			cfg.CassandraToSpannerConfigs.ProjectID = "default"
+			cfg.Listeners[i].Spanner.ProjectID = "default"
 			cfg.Listeners[i].Spanner.InstanceID = "default"
 		}
 		if cfg.Listeners[i].Spanner.ProjectID == "" {

--- a/third_party/datastax/proxy/defaults.go
+++ b/third_party/datastax/proxy/defaults.go
@@ -11,6 +11,8 @@ const (
 	DefaultSpannerMinSession   = 100
 	DefaultSpannerMaxSession   = 400
 	DefaultConfigTableName     = "TableConfigurations"
+	ExternalHostProjectID      = "default"
+	ExternalHostInstanceID     = "default"
 )
 
 // ApplyDefaults applies default values to the configuration after it is loaded
@@ -54,8 +56,8 @@ func ValidateAndApplyDefaults(cfg *UserConfig) error {
 			return fmt.Errorf("database id is not defined for listener %s %d", cfg.Listeners[i].Name, cfg.Listeners[i].Port)
 		}
 		if cfg.CassandraToSpannerConfigs.Endpoint != "" && !regexp.MustCompile(`.*\.googleapis\.com.*`).MatchString(cfg.CassandraToSpannerConfigs.Endpoint) {
-			cfg.Listeners[i].Spanner.ProjectID = "default"
-			cfg.Listeners[i].Spanner.InstanceID = "default"
+			cfg.Listeners[i].Spanner.ProjectID = ExternalHostProjectID
+			cfg.Listeners[i].Spanner.InstanceID = ExternalHostInstanceID
 		}
 		if cfg.Listeners[i].Spanner.ProjectID == "" {
 			if cfg.CassandraToSpannerConfigs.ProjectID == "" {

--- a/third_party/datastax/proxy/defaults.go
+++ b/third_party/datastax/proxy/defaults.go
@@ -1,6 +1,9 @@
 package proxy
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
 // Defaults for Spanner Settings.
 const (
@@ -49,6 +52,10 @@ func ValidateAndApplyDefaults(cfg *UserConfig) error {
 		}
 		if cfg.Listeners[i].Spanner.DatabaseID == "" {
 			return fmt.Errorf("database id is not defined for listener %s %d", cfg.Listeners[i].Name, cfg.Listeners[i].Port)
+		}
+		if cfg.CassandraToSpannerConfigs.Endpoint != "" && !regexp.MustCompile(`.*\.googleapis\.com.*`).MatchString(cfg.CassandraToSpannerConfigs.Endpoint) {
+			cfg.CassandraToSpannerConfigs.ProjectID = "default"
+			cfg.Listeners[i].Spanner.InstanceID = "default"
 		}
 		if cfg.Listeners[i].Spanner.ProjectID == "" {
 			if cfg.CassandraToSpannerConfigs.ProjectID == "" {

--- a/third_party/datastax/proxy/defaults_test.go
+++ b/third_party/datastax/proxy/defaults_test.go
@@ -198,7 +198,7 @@ func TestValidateExternalHostEndpointSetsDefaults(t *testing.T) {
 	if l.Spanner.InstanceID != "default" {
 		t.Errorf("Expected InstanceID to be 'default', got: %s", l.Spanner.InstanceID)
 	}
-	if cfg.CassandraToSpannerConfigs.ProjectID != "default" {
+	if l.Spanner.ProjectID != "default" {
 		t.Errorf("Expected ProjectID to be 'default', got: %s", cfg.CassandraToSpannerConfigs.ProjectID)
 	}
 }

--- a/third_party/datastax/proxy/defaults_test.go
+++ b/third_party/datastax/proxy/defaults_test.go
@@ -169,3 +169,61 @@ func TestValidateAndApplyDefaultsMissingDatabaseID(t *testing.T) {
 		t.Errorf("Expected error for missing DatabaseID, got: %v", err)
 	}
 }
+
+func TestValidateExternalHostEndpointSetsDefaults(t *testing.T) {
+	cfg := &UserConfig{
+		Listeners: []Listener{
+			{
+				Name: "Listener1",
+				Port: 8080,
+				Spanner: Spanner{
+					DatabaseID: "db-1",
+					InstanceID: "",
+					ProjectID:  "",
+				},
+			},
+		},
+		CassandraToSpannerConfigs: CassandraToSpannerConfigs{
+			Endpoint:  "localhost:9090", // ExternalHost endpoint
+			ProjectID: "",
+		},
+	}
+
+	err := ValidateAndApplyDefaults(cfg)
+	if err != nil {
+		t.Errorf("Did not expect an error, got: %v", err)
+	}
+
+	l := cfg.Listeners[0]
+	if l.Spanner.InstanceID != "default" {
+		t.Errorf("Expected InstanceID to be 'default', got: %s", l.Spanner.InstanceID)
+	}
+	if cfg.CassandraToSpannerConfigs.ProjectID != "default" {
+		t.Errorf("Expected ProjectID to be 'default', got: %s", cfg.CassandraToSpannerConfigs.ProjectID)
+	}
+}
+
+func TestValidateCloudSpannerEndpointMissingProjectAndInstance(t *testing.T) {
+	cfg := &UserConfig{
+		Listeners: []Listener{
+			{
+				Name: "Listener1",
+				Port: 8080,
+				Spanner: Spanner{
+					DatabaseID: "db-1",
+					InstanceID: "",
+					ProjectID:  "",
+				},
+			},
+		},
+		CassandraToSpannerConfigs: CassandraToSpannerConfigs{
+			Endpoint:  "spanner.googleapis.com:443", // Cloud Spanner endpoint
+			ProjectID: "",                           // Empty ProjectID
+		},
+	}
+	err := ValidateAndApplyDefaults(cfg)
+	expectedError := "project id is not defined for listener Listener1 8080"
+	if err == nil || err.Error() != expectedError {
+		t.Errorf("Expected error for missing ProjectID and InstanceID with Cloud Spanner endpoint, got: %v", err)
+	}
+}


### PR DESCRIPTION
This PR addresses 4 issues for the external host support:
- Removed externalHost parameter, instead any endpoint which doesn't contain *.googleapis.com can be considered as externalHost
- For externalHosts set project and instance to default so that project and instance is not mandatory when a connection is being made to an external host
- Updated the readme with the 4 new parameters introduced in the schema_convertor
- When connecting to an external host, project and instance will be set to default and need not be mentioned in the config file
- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
