### PR TITLE
Return VoidResult for Batch message

### DIFF
--- a/mocks/spanner/SpannerClientIface.go
+++ b/mocks/spanner/SpannerClientIface.go
@@ -135,25 +135,25 @@ func (_m *SpannerClientIface) DeleteUsingMutations(ctx context.Context, query re
 }
 
 // FilterAndExecuteBatch provides a mock function with given fields: ctx, queries
-func (_m *SpannerClientIface) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
+func (_m *SpannerClientIface) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.VoidResult, string, error) {
 	ret := _m.Called(ctx, queries)
 
 	if len(ret) == 0 {
 			panic("no return value specified for FilterAndExecuteBatch")
 	}
 
-	var r0 *message.RowsResult
+	var r0 *message.VoidResult
 	var r1 string  
 	var r2 error  
 
-	if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) (*message.RowsResult, string, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) (*message.VoidResult, string, error)); ok {
 			r0, r1, r2 = rf(ctx, queries) 
 	} else {
-			if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) *message.RowsResult); ok {
+			if rf, ok := ret.Get(0).(func(context.Context, []*responsehandler.QueryMetadata) *message.VoidResult); ok {
 					r0 = rf(ctx, queries)
 			} else {
 					if ret.Get(0) != nil {
-							r0 = ret.Get(0).(*message.RowsResult)
+							r0 = ret.Get(0).(*message.VoidResult)
 					}
 			}
 

--- a/spanner/spanner.go
+++ b/spanner/spanner.go
@@ -87,7 +87,7 @@ type SpannerClientIface interface {
 	InsertOrUpdateMutation(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
 	DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
 	UpdateMapByKey(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, string, error)
-	FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, string, error)
+	FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.VoidResult, string, error)
 	GetTableConfigs(ctx context.Context, query responsehandler.QueryMetadata) (map[string]map[string]*tableConfig.Column, map[string][]tableConfig.Column, *SystemQueryMetadataCache, error)
 }
 
@@ -714,7 +714,7 @@ func updateMapWithNewValues(mapValue map[string]bool, query *responsehandler.Que
 // Returns:
 //   - Error if the transaction fails.
 
-func (sc *SpannerClient) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, string, error) {
+func (sc *SpannerClient) FilterAndExecuteBatch(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.VoidResult, string, error) {
 	otelgo.AddAnnotation(ctx, FilterAndExecuteBatch)
 	var spannerAPI string
 	_, err := sc.Client.ReadWriteTransactionWithOptions(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
@@ -772,7 +772,7 @@ func (sc *SpannerClient) FilterAndExecuteBatch(ctx context.Context, queries []*r
 		return nil
 	}, spanner.TransactionOptions{CommitOptions: sc.BuildCommitOptions()})
 
-	return &rowsResult, spannerAPI, err
+	return &message.VoidResult{}, spannerAPI, err
 }
 
 // prepareQueries - Prepares mutations and DML statements for the transaction based on the provided queries.

--- a/spanner/spanner_test.go
+++ b/spanner/spanner_test.go
@@ -1043,7 +1043,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with same PK: %v", err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithSamePK")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllInsertWithSamePK")
 			assert.Equal(t, CommitAPI, spannerAPI)
 		}
 
@@ -1089,7 +1089,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with different PK: %v", err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithDifferentPK")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllInsertWithDifferentPK")
 			assert.Equal(t, CommitAPI, spannerAPI)
 		}
 
@@ -1129,7 +1129,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for range delete: %v", err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: RangeDelete")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch batch test case: RangeDelete")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
@@ -1242,7 +1242,7 @@ func TestFilterAndExecuteBatch(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error while executing FilterAndExecuteBatch for all insert with same PK: %v", err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllInsertWithSamePK")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllInsertWithSamePK")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
@@ -1302,7 +1302,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDelete")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: MultipleInsertFollowedByRangeDelete")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
@@ -1350,7 +1350,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertWithSamePKFollowedByDelete")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: MultipleInsertWithSamePKFollowedByDelete")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
@@ -1427,7 +1427,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDeleteOnSamePK")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: MultipleInsertFollowedByRangeDeleteOnSamePK")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
@@ -1482,7 +1482,7 @@ func TestFilterAndExecuteBatch2(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: MultipleInsertFollowedByRangeDeleteOnDifferentPK")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: MultipleInsertFollowedByRangeDeleteOnDifferentPK")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 
@@ -1551,7 +1551,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKCase1")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllOperationWithSamePKCase1")
 			assert.Equal(t, ExecuteBatchDMLAPI, spannerAPI)
 		}
 		_, err = getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_comm_upload_event WHERE `user_id`='same_pk_9' order by upload_time;")
@@ -1629,7 +1629,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKey")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllOperationWithSamePKUpdateMapByKey")
 			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		_, err = getDataFromSpanner(ctx, sc.Client, fmt.Sprintf("select * from %s WHERE `user_id`='same_pk_10';", TABLE_ADDRESS))
@@ -1707,7 +1707,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
 			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_11';")
@@ -1798,7 +1798,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase3")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase3")
 			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_12';")
@@ -1883,7 +1883,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
 			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_13';")
@@ -1941,7 +1941,7 @@ func TestFilterAndExecuteBatch3(t *testing.T) {
 		if err != nil {
 			t.Errorf(ErrorWhileFilterAndExecuteBatch, err)
 		} else {
-			assert.Equal(t, 0, len(result.Data), "Unexpected number of rows in result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
+			assert.Equal(t, &message.VoidResult{}, result, "Unexpected result for batch test case: AllOperationWithSamePKUpdateMapByKeyCase2")
 			assert.Equal(t, UnknownOrMixedAPI, spannerAPI)
 		}
 		data, err := getDataFromSpanner(ctx, sc.Client, "select * from keyspace1_address_book_entries WHERE `user_id`='same_pk_13';")

--- a/third_party/datastax/proxy/proxy_test.go
+++ b/third_party/datastax/proxy/proxy_test.go
@@ -1238,7 +1238,7 @@ type MockSpannerClient struct {
 	InsertOrUpdateMutationFunc        func(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
 	UpdateMapByKeyFunc                func(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
 	DeleteUsingMutationsFunc          func(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error)
-	FilterAndExecuteBatchFunc         func(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.RowsResult, error)
+	FilterAndExecuteBatchFunc         func(ctx context.Context, queries []*responsehandler.QueryMetadata) (*message.VoidResult, error)
 }
 
 func (m *MockSpannerClient) DeleteUsingMutations(ctx context.Context, query responsehandler.QueryMetadata) (*message.RowsResult, error) {


### PR DESCRIPTION
As per https://github.com/apache/cassandra/blob/trunk/doc/native_protocol_v4.spec#L562, we should return void response in case of BATCH messages.