### PR TITLE
feat: support select float32 column as float

### DIFF
--- a/responsehandler/responsehandler.go
+++ b/responsehandler/responsehandler.go
@@ -26,12 +26,12 @@ import (
 	"cloud.google.com/go/civil"
 	"cloud.google.com/go/spanner"
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/datastax/go-cassandra-native-protocol/datatype"
-	"github.com/datastax/go-cassandra-native-protocol/message"
-	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/tableConfig"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/third_party/datastax/proxycore"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/utilities"
+	"github.com/datastax/go-cassandra-native-protocol/datatype"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"go.uber.org/zap"
 )
 
@@ -85,13 +85,17 @@ type TypeHandler struct {
 	ProtocalV primitive.ProtocolVersion
 }
 
-// GetColumnMeta retrieves the metadata for a column based on the provided query metadata.
+// GetColumnMeta retrieves the metadata for a column based on the provided query
+// metadata.
 // Parameters:
 //   - columnName: Name of the column to get metadata for.
 //   - query: QueryMetadata containing details about the query.
 //
 // Returns: Column metadata as a string and an error if any.
-func (th *TypeHandler) GetColumnMeta(columnName string, tableName string) (string, error) {
+func (th *TypeHandler) GetColumnMeta(
+	columnName string,
+	tableName string,
+) (string, error) {
 	metaStr, err := th.TableConfig.GetColumnType(tableName, columnName)
 	if err != nil {
 		return "", err
@@ -99,7 +103,8 @@ func (th *TypeHandler) GetColumnMeta(columnName string, tableName string) (strin
 	return metaStr.CQLType, nil
 }
 
-// TypeConversionForWriteTime converts a time.Time value to a byte slice for write operations,
+// TypeConversionForWriteTime converts a time.Time value to a byte slice for
+// write operations,
 // encoding it into a format compatible with the specified protocol version.
 //
 // Parameters:
@@ -112,15 +117,23 @@ func (th *TypeHandler) TypeConversionForWriteTime(s time.Time) ([]byte, error) {
 	var bytes []byte
 	var err error
 	timeInMicrosecond := s.UnixMicro()
-	bytes, err = proxycore.EncodeType(datatype.Bigint, th.ProtocalV, timeInMicrosecond)
+	bytes, err = proxycore.EncodeType(
+		datatype.Bigint,
+		th.ProtocalV,
+		timeInMicrosecond,
+	)
 	if err != nil {
 		th.Logger.Error("Error while Encoding Timestamp -> ", zap.Error(err))
 	}
 	return bytes, err
 }
 
-// function to encode rows - [][]interface{} to cassandra supported response formate [][][]bytes
-func (th *TypeHandler) BuildResponseForSystemQueries(rows [][]interface{}, protocalV primitive.ProtocolVersion) ([]message.Row, error) {
+// function to encode rows - [][]interface{} to cassandra supported response
+// formate [][][]bytes
+func (th *TypeHandler) BuildResponseForSystemQueries(
+	rows [][]interface{},
+	protocalV primitive.ProtocolVersion,
+) ([]message.Row, error) {
 	var allRows []message.Row
 	for _, row := range rows {
 		var mr message.Row
@@ -136,8 +149,9 @@ func (th *TypeHandler) BuildResponseForSystemQueries(rows [][]interface{}, proto
 	return allRows, nil
 }
 
-// BuildColumnMetadata constructs metadata for columns based on the given Spanner row type and query metadata.
-// It returns a slice of functions to process each column and a slice of column metadata.
+// BuildColumnMetadata constructs metadata for columns based on the given
+// Spanner row type and query metadata. It returns a slice of functions to
+// process each column and a slice of column metadata.
 //
 // Parameters:
 // - rowType: The Spanner row type containing field definitions.
@@ -149,10 +163,12 @@ func (th *TypeHandler) BuildResponseForSystemQueries(rows [][]interface{}, proto
 // - A slice of functions to process each column.
 // - A slice of column metadata.
 // - An error if any issues arise during processing.
-func (th *TypeHandler) BuildColumnMetadata(rowType *spannerpb.StructType,
+func (th *TypeHandler) BuildColumnMetadata(
+	rowType *spannerpb.StructType,
 	protocalV primitive.ProtocolVersion,
 	aliasMap map[string]tableConfig.AsKeywordMeta,
-	tableName, keyspace string) ([]func(int, *spanner.Row) ([]byte, error), []*message.ColumnMetadata, error) {
+	tableName, keyspace string,
+) ([]func(int, *spanner.Row) ([]byte, error), []*message.ColumnMetadata, error) {
 
 	var (
 		rowFuncs []func(int, *spanner.Row) ([]byte, error)
@@ -193,7 +209,10 @@ func (th *TypeHandler) BuildColumnMetadata(rowType *spannerpb.StructType,
 				dt = datatype.Bigint
 				rowFunc = th.HandleCassandraWriteTimeFuncType
 			default:
-				return nil, nil, fmt.Errorf("unknown cassandra type for spanner timestamp - %s", cqlType)
+				return nil, nil, fmt.Errorf(
+					"unknown cassandra type for spanner timestamp - %s",
+					cqlType,
+				)
 			}
 		case spannerpb.TypeCode_BYTES:
 			dt = datatype.Blob
@@ -234,7 +253,7 @@ func (th *TypeHandler) BuildColumnMetadata(rowType *spannerpb.StructType,
 			switch cqlType {
 			case floatType:
 				dt = datatype.Float
-				rowFunc = th.HandleCassandraFloatType
+				rowFunc = th.HandleCassandraFloatTypeFromSpannerFloat64
 			case doubleType:
 				dt = datatype.Double
 				rowFunc = th.HandleCassandraDoubleType
@@ -244,8 +263,14 @@ func (th *TypeHandler) BuildColumnMetadata(rowType *spannerpb.StructType,
 		case spannerpb.TypeCode_DATE:
 			dt = datatype.Date
 			rowFunc = th.HandleCassandraDateType
+		case spannerpb.TypeCode_FLOAT32:
+			dt = datatype.Float
+			rowFunc = th.HandleCassandraFloatTypeFromSpannerFloat32
 		default:
-			return nil, cmd, fmt.Errorf("spanner type is not handled - %v", field.Type.Code)
+			return nil, cmd, fmt.Errorf(
+				"spanner type is not handled - %v",
+				field.Type.Code,
+			)
 		}
 
 		rowFuncs = append(rowFuncs, rowFunc)
@@ -261,21 +286,31 @@ func (th *TypeHandler) BuildColumnMetadata(rowType *spannerpb.StructType,
 	return rowFuncs, cmd, nil
 }
 
-// BuildResponseRow constructs a response row by applying a series of functions to each column of a Spanner row.
-// It uses the provided row functions to encode each column and constructs a message row.
+// BuildResponseRow constructs a response row by applying a series of functions
+// to each column of a Spanner row. It uses the provided row functions to encode
+// each column and constructs a message row.
 //
 // Parameters:
 // - row: The Spanner row to be processed.
 // - rowFuncs: A slice of functions to process each column in the row.
 // Returns:
-// - A message.Row, which is a slice of byte slices representing the encoded columns.
+// - A message.Row, which is a slice of byte slices representing the encoded
+// columns.
 // - An error if any issues arise during processing.
-func (th *TypeHandler) BuildResponseRow(row *spanner.Row, rowFuncs []func(int, *spanner.Row) ([]byte, error)) (message.Row, error) {
+func (th *TypeHandler) BuildResponseRow(
+	row *spanner.Row,
+	rowFuncs []func(int, *spanner.Row) ([]byte, error),
+) (message.Row, error) {
 	var mr message.Row
 	for i, rowFunc := range rowFuncs {
 		byteData, err := rowFunc(i, row)
 		if err != nil {
-			return nil, fmt.Errorf("error while encoding data - %v, %d, %v ", err, i, row)
+			return nil, fmt.Errorf(
+				"error while encoding data - %v, %d, %v ",
+				err,
+				i,
+				row,
+			)
 		}
 		mr = append(mr, byteData)
 	}
@@ -283,7 +318,10 @@ func (th *TypeHandler) BuildResponseRow(row *spanner.Row, rowFuncs []func(int, *
 }
 
 // handle encoding spanner data to cassandra bool type
-func (th *TypeHandler) HandleCassandraBoolType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraBoolType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullBool
 	if err := row.Column(i, &col); err != nil {
@@ -299,22 +337,53 @@ func (th *TypeHandler) HandleCassandraBoolType(i int, row *spanner.Row) ([]byte,
 	return nil, err
 }
 
-// handle encoding spanner data to cassandra float type
-func (th *TypeHandler) HandleCassandraFloatType(i int, row *spanner.Row) ([]byte, error) {
+// handle encoding spanner float64 data to cassandra float type
+func (th *TypeHandler) HandleCassandraFloatTypeFromSpannerFloat64(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullFloat64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Float64 data: %v", err)
 	}
 	if col.Valid {
-		return proxycore.EncodeType(datatype.Float, th.ProtocalV, float32(col.Float64))
+		return proxycore.EncodeType(
+			datatype.Float,
+			th.ProtocalV,
+			float32(col.Float64),
+		)
+	}
+	return nil, err
+
+}
+
+// handle encoding spanner float32 data to cassandra float type
+func (th *TypeHandler) HandleCassandraFloatTypeFromSpannerFloat32(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
+	var err error
+	var col spanner.NullFloat32
+	if err := row.Column(i, &col); err != nil {
+		return nil, fmt.Errorf("failed to retrieve Float32 data: %v", err)
+	}
+	if col.Valid {
+		return proxycore.EncodeType(
+			datatype.Float,
+			th.ProtocalV,
+			float32(col.Float32),
+		)
 	}
 	return nil, err
 
 }
 
 // handle encoding spanner data to cassandra Double type
-func (th *TypeHandler) HandleCassandraDoubleType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraDoubleType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullFloat64
 	if err := row.Column(i, &col); err != nil {
@@ -328,7 +397,10 @@ func (th *TypeHandler) HandleCassandraDoubleType(i int, row *spanner.Row) ([]byt
 }
 
 // handle encoding spanner data to cassandra blob type
-func (th *TypeHandler) HandleCassandraBlobType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraBlobType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []byte
 	var err error
 	if err = row.Column(i, &col); err != nil {
@@ -341,14 +413,26 @@ func (th *TypeHandler) HandleCassandraBlobType(i int, row *spanner.Row) ([]byte,
 }
 
 // handle encoding spanner data to cassandra date type
-func (th *TypeHandler) HandleCassandraDateType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraDateType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col spanner.NullDate
 	var err error
 	if err = row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Date data: %v", err)
 	}
 	if col.Valid {
-		date := time.Date(col.Date.Year, col.Date.Month, col.Date.Day, 0, 0, 0, 0, time.UTC)
+		date := time.Date(
+			col.Date.Year,
+			col.Date.Month,
+			col.Date.Day,
+			0,
+			0,
+			0,
+			0,
+			time.UTC,
+		)
 		daysSinceEpoch := ConvertToCQLDate(date)
 		return proxycore.EncodeType(datatype.Date, th.ProtocalV, daysSinceEpoch)
 	}
@@ -356,7 +440,10 @@ func (th *TypeHandler) HandleCassandraDateType(i int, row *spanner.Row) ([]byte,
 }
 
 // handle encoding spanner data to cassandra timestamp type
-func (th *TypeHandler) HandleCassandraTimestampType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraTimestampType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col spanner.NullTime
 	var err error
 	if err := row.Column(i, &col); err != nil {
@@ -369,7 +456,10 @@ func (th *TypeHandler) HandleCassandraTimestampType(i int, row *spanner.Row) ([]
 }
 
 // handle encoding spanner timestamp to cassandra Bigint type
-func (th *TypeHandler) HandleCassandraWriteTimeFuncType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraWriteTimeFuncType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var byteData []byte = nil
 	var col spanner.NullTime
@@ -383,7 +473,10 @@ func (th *TypeHandler) HandleCassandraWriteTimeFuncType(i int, row *spanner.Row)
 }
 
 // handle encoding spanner data to cassandra text type
-func (th *TypeHandler) HandleCassandraTextType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraTextType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullString
 	if err = row.Column(i, &col); err != nil {
@@ -396,7 +489,10 @@ func (th *TypeHandler) HandleCassandraTextType(i int, row *spanner.Row) ([]byte,
 }
 
 // handle encoding spanner data to cassandra Uuid type
-func (th *TypeHandler) HandleCassandraUuidType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraUuidType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullString
 	if err = row.Column(i, &col); err != nil {
@@ -409,7 +505,10 @@ func (th *TypeHandler) HandleCassandraUuidType(i int, row *spanner.Row) ([]byte,
 }
 
 // handle encoding spanner data to cassandra Bigint type
-func (th *TypeHandler) HandleCassandraBigintType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraBigintType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullInt64
 	if err := row.Column(i, &col); err != nil {
@@ -422,7 +521,10 @@ func (th *TypeHandler) HandleCassandraBigintType(i int, row *spanner.Row) ([]byt
 }
 
 // handle encoding spanner data to cassandra Int type
-func (th *TypeHandler) HandleCassandraIntType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleCassandraIntType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var err error
 	var col spanner.NullInt64
 	if err := row.Column(i, &col); err != nil {
@@ -434,7 +536,8 @@ func (th *TypeHandler) HandleCassandraIntType(i int, row *spanner.Row) ([]byte, 
 	return nil, err
 }
 
-// getCqlType retrieves the CQL type for a given field name based on the query metadata.
+// getCqlType retrieves the CQL type for a given field name based on the query
+// metadata.
 //
 // Parameters:
 // - fieldName: The name of the field for which the CQL type is to be retrieved.
@@ -443,14 +546,20 @@ func (th *TypeHandler) HandleCassandraIntType(i int, row *spanner.Row) ([]byte, 
 // Returns:
 // - string: The CQL type of the specified field.
 // - error: An error object if the CQL type cannot be determined.
-func (th *TypeHandler) getCqlType(fieldName string, aliasMap map[string]tableConfig.AsKeywordMeta, tableName string) (string, error) {
+func (th *TypeHandler) getCqlType(
+	fieldName string,
+	aliasMap map[string]tableConfig.AsKeywordMeta,
+	tableName string,
+) (string, error) {
 	if meta, found := aliasMap[fieldName]; found {
 		return meta.CQLType, nil
 	}
 	return th.GetColumnMeta(fieldName, tableName)
 }
 
-func (th *TypeHandler) HandleMapType(dt datatype.DataType) (func(int, *spanner.Row) ([]byte, error), error) {
+func (th *TypeHandler) HandleMapType(
+	dt datatype.DataType,
+) (func(int, *spanner.Row) ([]byte, error), error) {
 	switch dt {
 	case utilities.MapTextCassandraType:
 		return th.HandleMapStringString, nil
@@ -478,7 +587,10 @@ func (th *TypeHandler) GetJsonString(i int, row *spanner.Row) (string, error) {
 }
 
 // handle encoding spanner data to cassandra map<varchar, bigint> type
-func (th *TypeHandler) HandleMapStringInt64(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleMapStringInt64(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var detailsField map[string]int64
 	jsonStr, err := th.GetJsonString(i, row)
 	if err != nil {
@@ -486,93 +598,161 @@ func (th *TypeHandler) HandleMapStringInt64(i int, row *spanner.Row) ([]byte, er
 	}
 
 	if err := json.Unmarshal([]byte(jsonStr), &detailsField); err != nil {
-		return nil, fmt.Errorf("error deserializing JSON to map[string]int64: %v", err)
+		return nil, fmt.Errorf(
+			"error deserializing JSON to map[string]int64: %v",
+			err,
+		)
 	}
-	bytes, err := proxycore.EncodeType(utilities.MapBigintCassandraType, th.ProtocalV, detailsField)
+	bytes, err := proxycore.EncodeType(
+		utilities.MapBigintCassandraType,
+		th.ProtocalV,
+		detailsField,
+	)
 	return bytes, err
 }
 
 // handle encoding spanner data to cassandra map<varchar, bool> type
-func (th *TypeHandler) HandleMapStringBool(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleMapStringBool(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var detailsField map[string]bool
 	jsonStr, err := th.GetJsonString(i, row)
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &detailsField); err != nil {
-		return nil, fmt.Errorf("error deserializing JSON to map[string]bool: %v", err)
+		return nil, fmt.Errorf(
+			"error deserializing JSON to map[string]bool: %v",
+			err,
+		)
 	}
-	bytes, err := proxycore.EncodeType(utilities.MapBooleanCassandraType, th.ProtocalV, detailsField)
+	bytes, err := proxycore.EncodeType(
+		utilities.MapBooleanCassandraType,
+		th.ProtocalV,
+		detailsField,
+	)
 	return bytes, err
 }
 
 // handle encoding spanner data to cassandra map<varchar, varchar> type
-func (th *TypeHandler) HandleMapStringString(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleMapStringString(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var detailsField map[string]string
 	jsonStr, err := th.GetJsonString(i, row)
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &detailsField); err != nil {
-		return nil, fmt.Errorf("error deserializing JSON to map[string]string: %v", err)
+		return nil, fmt.Errorf(
+			"error deserializing JSON to map[string]string: %v",
+			err,
+		)
 	}
-	bytes, err := proxycore.EncodeType(utilities.MapTextCassandraType, th.ProtocalV, detailsField)
+	bytes, err := proxycore.EncodeType(
+		utilities.MapTextCassandraType,
+		th.ProtocalV,
+		detailsField,
+	)
 	return bytes, err
 }
 
 // handle encoding spanner data to cassandra map<varchar, double> type
-func (th *TypeHandler) HandleMapStringFloat64(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleMapStringFloat64(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var detailsField map[string]float64
 	jsonStr, err := th.GetJsonString(i, row)
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &detailsField); err != nil {
-		return nil, fmt.Errorf("error deserializing JSON to map[string]float64: %v", err)
+		return nil, fmt.Errorf(
+			"error deserializing JSON to map[string]float64: %v",
+			err,
+		)
 	}
-	bytes, err := proxycore.EncodeType(utilities.MapDoubleCassandraType, th.ProtocalV, detailsField)
+	bytes, err := proxycore.EncodeType(
+		utilities.MapDoubleCassandraType,
+		th.ProtocalV,
+		detailsField,
+	)
 	return bytes, err
 }
 
 // handle encoding spanner data to cassandra map<varchar, date> type
-func (th *TypeHandler) HandleMapStringDate(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleMapStringDate(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col map[string]spanner.NullDate
 	jsonStr, err := th.GetJsonString(i, row)
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &col); err != nil {
-		return nil, fmt.Errorf("error deserializing JSON to map[string]date: %v", err)
+		return nil, fmt.Errorf(
+			"error deserializing JSON to map[string]date: %v",
+			err,
+		)
 	}
 
 	convertedMap := make(map[string]int32)
 	for key, nullDate := range col {
 		if nullDate.Valid {
-			date := time.Date(nullDate.Date.Year, nullDate.Date.Month, nullDate.Date.Day, 0, 0, 0, 0, time.UTC)
+			date := time.Date(
+				nullDate.Date.Year,
+				nullDate.Date.Month,
+				nullDate.Date.Day,
+				0,
+				0,
+				0,
+				0,
+				time.UTC,
+			)
 			daysSinceEpoch := ConvertToCQLDate(date)
 			convertedMap[key] = daysSinceEpoch
 		}
 	}
 
-	bytes, err := proxycore.EncodeType(utilities.MapDateCassandraType, th.ProtocalV, convertedMap)
+	bytes, err := proxycore.EncodeType(
+		utilities.MapDateCassandraType,
+		th.ProtocalV,
+		convertedMap,
+	)
 	return bytes, err
 }
 
 // handle encoding spanner data to cassandra map<varchar, timestamp> type
-func (th *TypeHandler) HandleMapStringTimestamp(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleMapStringTimestamp(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var detailsField map[string]time.Time
 	jsonStr, err := th.GetJsonString(i, row)
 	if err != nil {
 		return nil, err
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &detailsField); err != nil {
-		return nil, fmt.Errorf("error deserializing JSON to map[string]time.Time: %v", err)
+		return nil, fmt.Errorf(
+			"error deserializing JSON to map[string]time.Time: %v",
+			err,
+		)
 	}
-	bytes, err := proxycore.EncodeType(utilities.MapTimestampCassandraType, th.ProtocalV, detailsField)
+	bytes, err := proxycore.EncodeType(
+		utilities.MapTimestampCassandraType,
+		th.ProtocalV,
+		detailsField,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleArrayType(dt datatype.PrimitiveType) (func(int, *spanner.Row) ([]byte, error), error) {
+func (th *TypeHandler) HandleArrayType(
+	dt datatype.PrimitiveType,
+) (func(int, *spanner.Row) ([]byte, error), error) {
 	switch dt {
 	case utilities.ListTextCassandraType:
 		return th.HandleStringArrayType, nil
@@ -615,29 +795,47 @@ func (th *TypeHandler) HandleArrayType(dt datatype.PrimitiveType) (func(int, *sp
 	}
 }
 
-// The following functions (HandleInt64ArrayType, HandleStringArrayType, handle**ArrayType etc.) follow a similar pattern:
+// The following functions (HandleInt64ArrayType, HandleStringArrayType,
+// handle**ArrayType etc.) follow a similar pattern:
 // They handle the conversion of specific array types from Spanner to Cassandra.
 // Parameters are similar, involving the row reference, column index.
 // Each returns a Cassandra datatype, the converted bytes, and an error if any.
-func (th *TypeHandler) HandleInt64ArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleInt64ArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []int64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<Int64> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListBigintCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListBigintCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleInt64SetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleInt64SetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []int64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<Int64> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetBigintCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetBigintCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleInt32ArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleInt32ArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []int64
 	var col32 []int32
 	if err := row.Column(i, &col); err != nil {
@@ -648,11 +846,18 @@ func (th *TypeHandler) HandleInt32ArrayType(i int, row *spanner.Row) ([]byte, er
 		col32 = append(col32, int32(val))
 	}
 
-	bytes, err := proxycore.EncodeType(utilities.ListIntCassandraType, th.ProtocalV, col32)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListIntCassandraType,
+		th.ProtocalV,
+		col32,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleInt32SetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleInt32SetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []int64
 	var col32 []int32
 	if err := row.Column(i, &col); err != nil {
@@ -663,65 +868,114 @@ func (th *TypeHandler) HandleInt32SetType(i int, row *spanner.Row) ([]byte, erro
 		col32 = append(col32, int32(val))
 	}
 
-	bytes, err := proxycore.EncodeType(utilities.SetIntCassandraType, th.ProtocalV, col32)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetIntCassandraType,
+		th.ProtocalV,
+		col32,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleStringArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleStringArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []string
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<STRING> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListTextCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListTextCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleStringSetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleStringSetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []string
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<STRING> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetTextCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetTextCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleBoolArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleBoolArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []bool
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<BOOL> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListBooleanCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListBooleanCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleBoolSetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleBoolSetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []bool
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<BOOL> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetBooleanCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetBooleanCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleFloat64ArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleFloat64ArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []float64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<float64> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListDoubleCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListDoubleCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleFloat64SetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleFloat64SetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []float64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<float64> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetDoubleCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetDoubleCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleFloatArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleFloatArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []float64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<float64> data: %v", err)
@@ -730,11 +984,18 @@ func (th *TypeHandler) HandleFloatArrayType(i int, row *spanner.Row) ([]byte, er
 	for _, val := range col {
 		col32 = append(col32, float32(val))
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListFloatCassandraType, th.ProtocalV, col32)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListFloatCassandraType,
+		th.ProtocalV,
+		col32,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleFloatSetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleFloatSetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []float64
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<float64> data: %v", err)
@@ -743,11 +1004,18 @@ func (th *TypeHandler) HandleFloatSetType(i int, row *spanner.Row) ([]byte, erro
 	for _, val := range col {
 		col32 = append(col32, float32(val))
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetFloatCassandraType, th.ProtocalV, col32)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetFloatCassandraType,
+		th.ProtocalV,
+		col32,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleDateArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleDateArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []spanner.NullDate
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<date> data: %v", err)
@@ -762,11 +1030,18 @@ func (th *TypeHandler) HandleDateArrayType(i int, row *spanner.Row) ([]byte, err
 			cqlDates = append(cqlDates, defaultDate)
 		}
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListDateCassandraType, th.ProtocalV, cqlDates)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListDateCassandraType,
+		th.ProtocalV,
+		cqlDates,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleDateSetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleDateSetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []spanner.NullDate
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<date> data: %v", err)
@@ -781,29 +1056,50 @@ func (th *TypeHandler) HandleDateSetType(i int, row *spanner.Row) ([]byte, error
 			cqlDates = append(cqlDates, defaultDate)
 		}
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetDateCassandraType, th.ProtocalV, cqlDates)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetDateCassandraType,
+		th.ProtocalV,
+		cqlDates,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleTimestampArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleTimestampArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []time.Time
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<Timestamp> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListTimestampCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListTimestampCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleTimestampSetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleTimestampSetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col []time.Time
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<Timestamp> data: %v", err)
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetTimestampCassandraType, th.ProtocalV, col)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetTimestampCassandraType,
+		th.ProtocalV,
+		col,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleByteArrayType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleByteArrayType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col [][]byte
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve ARRAY<byte> data: %v", err)
@@ -812,11 +1108,18 @@ func (th *TypeHandler) HandleByteArrayType(i int, row *spanner.Row) ([]byte, err
 	for _, b := range col {
 		stringSlice = append(stringSlice, string(b))
 	}
-	bytes, err := proxycore.EncodeType(utilities.ListBlobCassandraType, th.ProtocalV, stringSlice)
+	bytes, err := proxycore.EncodeType(
+		utilities.ListBlobCassandraType,
+		th.ProtocalV,
+		stringSlice,
+	)
 	return bytes, err
 }
 
-func (th *TypeHandler) HandleByteSetType(i int, row *spanner.Row) ([]byte, error) {
+func (th *TypeHandler) HandleByteSetType(
+	i int,
+	row *spanner.Row,
+) ([]byte, error) {
 	var col [][]byte
 	if err := row.Column(i, &col); err != nil {
 		return nil, fmt.Errorf("failed to retrieve Set<byte> data: %v", err)
@@ -825,16 +1128,31 @@ func (th *TypeHandler) HandleByteSetType(i int, row *spanner.Row) ([]byte, error
 	for _, b := range col {
 		stringSlice = append(stringSlice, string(b))
 	}
-	bytes, err := proxycore.EncodeType(utilities.SetBlobCassandraType, th.ProtocalV, stringSlice)
+	bytes, err := proxycore.EncodeType(
+		utilities.SetBlobCassandraType,
+		th.ProtocalV,
+		stringSlice,
+	)
 	return bytes, err
 }
 
-// ConvertCivilDateToTime converts a civil.Date to a time.Time set to midnight UTC.
+// ConvertCivilDateToTime converts a civil.Date to a time.Time set to midnight
+// UTC.
 func ConvertCivilDateToTime(cDate civil.Date) time.Time {
-	return time.Date(cDate.Year, time.Month(cDate.Month), cDate.Day, 0, 0, 0, 0, time.UTC)
+	return time.Date(
+		cDate.Year,
+		time.Month(cDate.Month),
+		cDate.Day,
+		0,
+		0,
+		0,
+		0,
+		time.UTC,
+	)
 }
 
-// ConvertToCQLDate converts a time.Time to a CQL date as an int32 representing days since the Unix epoch.
+// ConvertToCQLDate converts a time.Time to a CQL date as an int32 representing
+// days since the Unix epoch.
 func ConvertToCQLDate(t time.Time) int32 {
 	return int32(t.Sub(unixEpoch).Hours() / 24)
 }

--- a/responsehandler/responsehandler_test.go
+++ b/responsehandler/responsehandler_test.go
@@ -22,13 +22,13 @@ import (
 	"time"
 
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/datastax/go-cassandra-native-protocol/datatype"
-	"github.com/datastax/go-cassandra-native-protocol/message"
-	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/responsehandler"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/tableConfig"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/third_party/datastax/proxycore"
 	"github.com/cloudspannerecosystem/cassandra-to-spanner-proxy/utilities"
+	"github.com/datastax/go-cassandra-native-protocol/datatype"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"go.uber.org/zap"
 )
 
@@ -372,6 +372,10 @@ func TestBuildColumnMetadata(t *testing.T) {
 						Name:    "column11",
 						CQLType: "uuid",
 					},
+					"column12": {
+						Name:    "column12",
+						CQLType: "float",
+					},
 				},
 			},
 			Logger: zap.NewNop(),
@@ -393,6 +397,7 @@ func TestBuildColumnMetadata(t *testing.T) {
 			{Name: "column9", Type: &spannerpb.Type{Code: spannerpb.TypeCode_TIMESTAMP}},
 			{Name: "column10", Type: &spannerpb.Type{Code: spannerpb.TypeCode_STRING}},
 			{Name: "column11", Type: &spannerpb.Type{Code: spannerpb.TypeCode_STRING}},
+			{Name: "column12", Type: &spannerpb.Type{Code: spannerpb.TypeCode_FLOAT32}},
 		},
 	}
 
@@ -408,6 +413,7 @@ func TestBuildColumnMetadata(t *testing.T) {
 		"column9":  {CQLType: "bigint", DataType: datatype.Bigint},
 		"column10": {CQLType: "text", DataType: datatype.Varchar},
 		"column11": {CQLType: "uuid", DataType: datatype.Uuid},
+		"column12": {CQLType: "float", DataType: datatype.Float},
 	}
 
 	rowFuncs, cmd, err := th.BuildColumnMetadata(rowType, primitive.ProtocolVersion4, aliasMap, "table1", "keyspace1")
@@ -416,12 +422,12 @@ func TestBuildColumnMetadata(t *testing.T) {
 		t.Fatalf("Expected no error, but got: %v", err)
 	}
 
-	if len(rowFuncs) != 11 { // Excluding spannerTTLColumn and spannerTSColumn
-		t.Fatalf("Expected 10 rowFuncs, but got: %d", len(rowFuncs))
+	if len(rowFuncs) != 12 { // Excluding spannerTTLColumn and spannerTSColumn
+		t.Fatalf("Expected 12 rowFuncs, but got: %d", len(rowFuncs))
 	}
 
-	if len(cmd) != 11 { // Excluding spannerTTLColumn and spannerTSColumn
-		t.Fatalf("Expected 10 column metadata entries, but got: %d", len(cmd))
+	if len(cmd) != 12 { // Excluding spannerTTLColumn and spannerTSColumn
+		t.Fatalf("Expected 12 column metadata entries, but got: %d", len(cmd))
 	}
 
 	expectedCmd := []*message.ColumnMetadata{
@@ -436,6 +442,7 @@ func TestBuildColumnMetadata(t *testing.T) {
 		{Keyspace: "keyspace1", Table: "table1", Name: "column9", Index: 9, Type: datatype.Bigint},
 		{Keyspace: "keyspace1", Table: "table1", Name: "column10", Index: 10, Type: datatype.Varchar},
 		{Keyspace: "keyspace1", Table: "table1", Name: "column11", Index: 11, Type: datatype.Uuid},
+		{Keyspace: "keyspace1", Table: "table1", Name: "column12", Index: 12, Type: datatype.Float},
 	}
 
 	for i, col := range cmd {


### PR DESCRIPTION
Currently if the column is `FLOAT32` in spanner but the mapped type is `float` in TableConfigurations, selecting this float column individually will cause `spanner type is not handled - FLOAT32` error.

This cl adds support for handling Spanner FLOAT32 type as a Cassandra float type using the new decode function `HandleCassandraFloatTypeFromSpannerFloat32`. Also renames the previous `HandleCassandraFloatType` func to `HandleCassandraFloatTypeFromSpannerFloat64` to be more clear.

`FLOAT64` and `FLOAT32` now can both be handled as Cassandra float if the mapped type is `float` in `TableConfigurations`.

The format changes are the result of g3 formatter vs code extension.